### PR TITLE
fix: modify MQTTClientConnection scanner execution order

### DIFF
--- a/app/port_scanner/port.go
+++ b/app/port_scanner/port.go
@@ -62,7 +62,6 @@ func PortScanner(host string, isBroker bool) []int {
 					continue
 				}
 				conn.Close()
-				fmt.Printf("%d open\n", port)
 				result = append(result, port)
 				wg.Done()
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 }
 
 type BrokerInfo struct {
+	TLS        bool     `json:"tls"`         // Enable TLS checker or not
 	Host       string   `json:"host"`        // Broker's host address
 	MQTTPort   int      `json:"mqtt_port"`   // Port for MQTT protocol
 	MQTTSPort  int      `json:"mqtts_port"`  // Port for MQTT over SSL protocol

--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,6 @@
 {
   "broker": {
+    "tls": false,
     "host": "broker.emqx.io",
     "mqtt_port": 1883,
     "ws_port": 8083,


### PR DESCRIPTION
1. Add 'tls' flag to indicate whether TLS version scanner is enabled
2. Execute `MQTTClientConnection` scanner after other scanners, as this scanner will affect other scanners