### PR TITLE
feat: release MQTT-security-scanner by github action

### DIFF
--- a/.github/workflows/release-scanner.yml
+++ b/.github/workflows/release-scanner.yml
@@ -1,0 +1,41 @@
+name: Release MQTT security scanner
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name for this release'
+        required: true
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - if: github.event_name == 'workflow_dispatch'
+        run: |
+          git tag ${{ github.event.inputs.tag }}
+      - name: Set up Go
+        uses: actions/setup-go@v4
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
Use [goreleaser-action](https://github.com/goreleaser/goreleaser-action) to release MQTT-security-scanner

Demo: https://github.com/xavier-hou/mqtt-security-scanner/releases/tag/v1.0.0

Command
```
git tag v1.0.0 && git push --tag
```